### PR TITLE
add homepage url for rubygems gemspec validation

### DIFF
--- a/amdirent_stripe.gemspec
+++ b/amdirent_stripe.gemspec
@@ -11,13 +11,13 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{Stripe Helper methods for models with a stripe_key column.}
   spec.description   = %q{Helpers for Stripe}
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.homepage      = "https://github.com/amdirent/amdirent_stripe"
   spec.license       = "MIT"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
+    spec.metadata['allowed_push_host'] = "https://github.com/amdirent/amdirent_stripe"
   else
     raise "RubyGems 2.0 or newer is required to protect against " \
       "public gem pushes."


### PR DESCRIPTION
newer versions of ruby gems and bundler raise errors if the .gemspec file isn't totally filled out, preventing you from bundling.

https://github.com/bundler/bundler/issues/3781